### PR TITLE
correctly match error msg for path which include :

### DIFF
--- a/autoload/synta/go.vim
+++ b/autoload/synta/go.vim
@@ -27,7 +27,11 @@ function! synta#go#parse_errors(lines) abort
 
     for line in a:lines
         let fatalerrors = matchlist(line, '^\(fatal error:.*\)$')
-        let tokens = matchlist(line, '^\s*\(.\{-}\):\(\d\+\):\s*\(.*\)')
+        let tokens = matchlist(line, '^\s*\(.*\):\(\d\+\):\d\+:\s*\(.*\)$')
+
+        if len(tokens) >= 2 && tokens[1] =~ "^# "
+            continue
+        endif
 
         if !empty(fatalerrors)
             call add(errors, {"text": fatalerrors[1]})


### PR DESCRIPTION
Before this patch synta will not work on the file with following path:
~/go/src/scratch/2019-08-05+11:21:54/main.go